### PR TITLE
Replace pattern synonyms with template haskell

### DIFF
--- a/cube-solver.cabal
+++ b/cube-solver.cabal
@@ -35,7 +35,7 @@ library
                       CFOP.F2L,
                       CFOP.Cross,
                       Triggers,
-                      MoveExpr
+                      AlgExpr
 
     build-depends:    base ^>=4.17.2.1,
                       mtl,

--- a/cube-solver.cabal
+++ b/cube-solver.cabal
@@ -34,7 +34,8 @@ library
                       CFOP.OLL,
                       CFOP.F2L,
                       CFOP.Cross,
-                      Triggers
+                      Triggers,
+                      MoveExpr
 
     build-depends:    base ^>=4.17.2.1,
                       mtl,
@@ -47,7 +48,8 @@ library
                       servant-server,
                       wai,
                       warp,
-                      bytestring
+                      bytestring,
+                      template-haskell
 
     hs-source-dirs:   src
 

--- a/src/AlgExpr.hs
+++ b/src/AlgExpr.hs
@@ -1,0 +1,20 @@
+module AlgExpr where
+
+import qualified Language.Haskell.TH as TH
+import Language.Haskell.TH.Quote
+import CubeParser
+import Text.Megaparsec (runParser)
+import qualified Data.Text as T
+import Language.Haskell.TH.Syntax (liftData)
+
+algExpr :: QuasiQuoter
+algExpr = QuasiQuoter { quoteExp  = parseAlgExprExp
+                      , quotePat  = undefined
+                      , quoteType = undefined
+                      , quoteDec  = undefined
+                      }
+
+parseAlgExprExp :: String -> TH.Q TH.Exp
+parseAlgExprExp input = case runParser parseScramble "" (T.pack input) of
+    Left _ -> error "failed"
+    Right alg -> liftData alg

--- a/src/CFOP/Cross.hs
+++ b/src/CFOP/Cross.hs
@@ -25,7 +25,7 @@ solveCross' (x:xs) solvedPieces = do
     return $ moves ++ rest
 solveCross' [] _ = do
     cubeState <- get
-    case tryAlg [[], [D], [D'], [D2]] cubeState crossSolved of
+    case tryAlg [[], [Move DFace Normal], [Move DFace Prime], [Move DFace Two]] cubeState crossSolved of
         Left errorMessage -> error $ "Failed doing last move of cross: " ++ errorMessage 
         Right alg -> applyAlgorithm alg
 
@@ -87,10 +87,10 @@ midMove cubeState x = let
     unsolvedEdge = x cubeState
     edgeSum = pieceSum unsolvedEdge in
     case solvedEdge of
-        Edge Green Red -> if edgeSum == 0 then R' else F
-        Edge Green Orange -> if edgeSum == 0 then L else F'
-        Edge Blue Red -> if edgeSum == 0 then R else B'
-        Edge Blue Orange -> if edgeSum == 0 then L' else B
+        Edge Green Red -> if edgeSum == 0 then Move RFace Prime else Move FFace Normal
+        Edge Green Orange -> if edgeSum == 0 then Move LFace Normal else Move FFace Prime
+        Edge Blue Red -> if edgeSum == 0 then Move RFace Normal else Move BFace Prime
+        Edge Blue Orange -> if edgeSum == 0 then Move LFace Prime else Move BFace Normal
         _ -> error $ show solvedEdge
 
 

--- a/src/CFOP/F2L.hs
+++ b/src/CFOP/F2L.hs
@@ -95,11 +95,11 @@ fixOrientation slot (Just eSlot) (Just cSlot) = do
     let solvedEdge = fst $ f2lSlot solvedCube slot
     let edge = edgeInEdgeList cubeState solvedEdge
     if eSlot == cSlot
-        then applyAlgorithm [slotToMove eSlot, U, reverseMove $ slotToMove eSlot]
+        then applyAlgorithm [slotToMove eSlot, Move UFace Normal, reverseMove $ slotToMove eSlot]
         else if eSlot == slot && pieceSum edge == 0
-            then applyAlgorithm [slotToMove cSlot, U, reverseMove $ slotToMove cSlot]
+            then applyAlgorithm [slotToMove cSlot, Move UFace Normal, reverseMove $ slotToMove cSlot]
             else do
-            moves <- applyAlgorithm [edgeOrientationMove eSlot edge, U, reverseMove $ edgeOrientationMove eSlot edge]
+            moves <- applyAlgorithm [edgeOrientationMove eSlot edge, Move UFace Normal, reverseMove $ edgeOrientationMove eSlot edge]
             restMoves <- fixOrientation slot Nothing (Just cSlot)
             return $ moves ++ restMoves
 
@@ -107,19 +107,19 @@ orientationMoves :: F2LSlot -> Edge -> [Algorithm]
 orientationMoves slot edge = let m = edgeOrientationMove slot edge in [[m, aufMove, reverseMove m] | aufMove <- aufMoves]
 
 slotToMove :: F2LSlot -> Move
-slotToMove FL = L'
-slotToMove FR = R
-slotToMove BL = L
-slotToMove BR = R'
+slotToMove FL = Move LFace Prime
+slotToMove FR = Move RFace Normal
+slotToMove BL = Move LFace Normal
+slotToMove BR = Move RFace Prime
 
 edgeOrientationMove :: F2LSlot -> Edge -> Move
 edgeOrientationMove slot edge = if pieceSum edge == 0 then slotToMove slot else slotToNonOrientedMove slot
 
 slotToNonOrientedMove :: F2LSlot -> Move
-slotToNonOrientedMove FL = F
-slotToNonOrientedMove FR = F'
-slotToNonOrientedMove BL = B'
-slotToNonOrientedMove BR = B
+slotToNonOrientedMove FL = Move FFace Normal
+slotToNonOrientedMove FR = Move FFace Prime
+slotToNonOrientedMove BL = Move BFace Prime
+slotToNonOrientedMove BR = Move BFace Normal
 
 edgeSlot :: CubeState -> Edge -> Maybe F2LSlot
 edgeSlot = pieceSlot (zip allPairs allEdges)
@@ -176,7 +176,7 @@ getStatesFromState sideMove (alg, cubeState) = do
     step4
 
 branchWithU :: (Algorithm, CubeState) -> [(Algorithm, CubeState)]
-branchWithU = branchWithMoves [U, U', U2]
+branchWithU = branchWithMoves [Move UFace Normal, Move UFace Prime, Move UFace Two]
 
 branchWithMoves :: [Move] -> (Algorithm, CubeState) -> [(Algorithm, CubeState)]
 branchWithMoves (x:xs) (alg, cubeState) = 

--- a/src/CFOP/OLL.hs
+++ b/src/CFOP/OLL.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE QuasiQuotes #-}
 module CFOP.OLL (oll, ollSolved) where
 
 import Cube
@@ -6,6 +7,7 @@ import CubeState
 import Control.Monad.State
 import CFOP.Cross (crossSolved)
 import CFOP.F2L (f2lSolved)
+import AlgExpr
 
 oll :: Cube Algorithm
 oll = do
@@ -76,67 +78,67 @@ angleFlip = do
 
 dotFlipAlgs :: [Algorithm]
 dotFlipAlgs = applyFourSidesAlg
-    [ [R, U2, R2, F, R, F', U2, R', F, R, F']
-    , [L, F, L', U2, R, U2, R', U2, L, F', L']
-    , [F, U, R, U', R', F', U, F, R, U, R', U', F']
-    , [F, U, R, U', R', F', U', F, R, U, R', U', F']
-    , [R, U, R', U, R', F, R, F', U2, R', F, R, F']
-    , [R, U2, R2, F, R, F', U2, R', L, F, R, F', L']
-    , [L', R, B, R, B, R', B', R2, L, F, R, F']
-    , [L, F, R', F', R2, L2, B, R, B', R', B', R', L]
+    [ [algExpr|R U2 R2 F R F' U2 R' F R F'|]
+    , [algExpr|L F L' U2 R U2 R' U2 L F' L'|]
+    , [algExpr|F U R U' R' F' U F R U R' U' F'|]
+    , [algExpr|F U R U' R' F' U' F R U R' U' F'|]
+    , [algExpr|R U R' U R' F R F' U2 R' F R F'|]
+    , [algExpr|R U2 R2 F R F' U2 R' L F R F' L'|]
+    , [algExpr|L' R B R B R' B' R2 L F R F'|]
+    , [algExpr|L F R' F' R2 L2 B R B' R' B' R' L|]
     ]
 
 -- Line flip algs
 
 lineFlipAlgs :: [Algorithm]
 lineFlipAlgs = applyFourSidesAlg
-    [ [F, U, R, U', R2, F', R, U, R, U', R']
-    , [R', F, R, U, R', F', R, F, U', F']
-    , [L', B', L, R', U', R, U, L', B, L]
-    , [L, F, L', R, U, R', U', L, F', L']
+    [ [algExpr|F U R U' R2 F' R U R U' R'|]
+    , [algExpr|R' F R U R' F' R F U' F'|]
+    , [algExpr|L' B' L R' U' R U L' B L|]
+    , [algExpr|L F L' R U R' U' L F' L'|]
     , sexy ++ sledgeHammer
-    , [R, U, R2, U', R', F, R, U, R, U', F']
-    , [L, F', L', U', L, U, F, U', L']
-    , [R', F, R, U, R', U', F', U, R]
-    , F : sexy ++ [F']
-    , [R', U', R', F, R, F', U, R]
-    , [F, U, R, U', R', U, R, U', R', F']
-    , [R, U, R', U, R, U', B, U', B', R']
-    , [R', F, R, U, R, U', R2, F', R2, U', R', U, R, U, R']
-    , [L, F, L', U, R, U', R', U, R, U', R', L, F', L']
-    , [R, U, R', U', R', L, F, R, F', L']
+    , [algExpr|R U R2 U' R' F R U R U' F'|]
+    , [algExpr|L F' L' U' L U F U' L'|]
+    , [algExpr|R' F R U R' U' F' U R|]
+    , [algExpr|F|] ++ sexy ++ [algExpr|F'|]
+    , [algExpr|R' U' R' F R F' U R|]
+    , [algExpr|F U R U' R' U R U' R' F'|]
+    , [algExpr|R U R' U R U' B U' B' R'|]
+    , [algExpr|R' F R U R U' R2 F' R2 U' R' U R U R'|]
+    , [algExpr|L F L' U R U' R' U R U' R' L F' L'|]
+    , [algExpr|R U R' U' R' L F R F' L'|]
     ]
 -- Angle flip algs
 
 angleFlipAlgs :: [Algorithm]
 angleFlipAlgs = applyFourSidesAlg 
-    [ [R', F2, L, F, L', F, R]
-    , [L, F2, R', F', R, F', L']
-    , [L, F, R', F, R, F2, L']
-    , [R', F', L, F', L', F2, R]
-    , [R, U, R', U', R', F, R2, U, R', U', F']
-    , [R, U, R', U, R', F, R, F', R, U2, R']
-    , [L, F, R', F, R', D, R, D', R, F2, L']
-    , [R2, L, F', R, F', R', F2, R, F', R, L']
-    , [L, F, R', F', L', R, U, R, U', R']
-    , [R, U, R', U', R, U', R', F', U', F, R, U, R']
-    , [F, R', F, R2, U', R', U', R, U, R', F2]
-    , [R', U', F, U, R, U', R', F', R]
-    , [L, U, F', U', L', U, L, F, L']
-    , [R, U2, R2, F, R, F', R, U2, R']
-    , [L', U', L, U', L', U, L, U, L, F', L', F]
-    , [F, R', F', R, U, R, U', R']
-    , [R, U, R', U, R, U', R', U', R', F, R, F']
-    , [R, U, R', U, R, U2, R', F, R, U, R', U', F']
-    , [R', U', R, U', R', U2, R, F, R, U, R', U', F']
-    , [F', U', L', U, L, F]
-    , F : reverseSexy ++ [F']
-    , [R', U', R', F, R, F', R', F, R, F', U, R]
-    , [F, R, U, R', U', R, U, R', U', F']
-    , [L, F', L2, B, L2, F, L2, B', L]
-    , [L', B, L2, F', L2, B', L2, F, L']
-    , [R', F2, L, F, L', F', L, F, L', F, R]
-    , [L, F2, R', F', R, F, R', F', R, F', L']
+    [ [algExpr|R' F2 L F L' F R|]
+    , [algExpr|L F2 R' F' R F' L'|]
+    , [algExpr|L F R' F R F2 L'|]
+    , [algExpr|R' F' L F' L' F2 R|]
+    , [algExpr|R U R' U' R' F R2 U R' U' F'|]
+    , [algExpr|R U R' U R' F R F' R U2 R'|]
+    , [algExpr|L F R' F R' D R D' R F2 L'|]
+    , [algExpr|R2 L F' R F' R' F2 R F' R L'|]
+    , [algExpr|L F R' F' L' R U R U' R'|]
+    , [algExpr|R U R' U' R U' R' F' U' F R U R'|]
+    , [algExpr|F R' F R2 U' R' U' R U R' F2|]
+    , [algExpr|R' U' F U R U' R' F' R|]
+    , [algExpr|L U F' U' L' U L F L'|]
+    , [algExpr|R U2 R2 F R F' R U2 R'|]
+    , [algExpr|L' U' L U' L' U L U L F' L' F|]
+    , [algExpr|F R' F' R U R U' R'|]
+    , [algExpr|R U R' U R U' R' U' R' F R F'|]
+    , [algExpr|R U R' U R U2 R' F R U R' U' F'|]
+    , [algExpr|R' U' R U' R' U2 R F R U R' U' F'|]
+    , [algExpr|F' U' L' U L F|]
+    , [algExpr|F|] ++ reverseSexy ++ [algExpr|F'|]
+    , [algExpr|R' U' R' F R F' R' F R F' U R|]
+    , [algExpr|F R U R' U' R U R' U' F'|]
+    , [algExpr|L F' L2 B L2 F L2 B' L|]
+    , [algExpr|L' B L2 F' L2 B' L2 F L'|]
+    , [algExpr|R' F2 L F L' F' L F L' F R|]
+    , [algExpr|L F2 R' F' R F R' F' R F' L'|]
     ]
 
 -- Edges oriented algs
@@ -146,22 +148,22 @@ edgesOrientedAlgs = [] : applyFourSidesAlg
     [sune, antisune, hOll, lOll, piOll, tOll, uOll]
 
 sune :: Algorithm
-sune = [R, U, R', U, R, U2, R']
+sune = [algExpr|R U R' U R U2 R'|]
 
 antisune :: Algorithm
 antisune = reverseMoveSeq sune
 
 hOll :: Algorithm
-hOll = [R, U, R', U, R, U', R', U, R, U2, R']
+hOll = [algExpr|R U R' U R U' R' U R U2 R'|]
 
 lOll :: Algorithm
-lOll = [F, R', F', L, F, R, F', L']
+lOll = [algExpr|F R' F' L F R F' L'|]
 
 piOll :: Algorithm
-piOll = [R, U2, R2, U', R2, U', R2, U2, R]
+piOll = [algExpr|R U2 R2 U' R2 U' R2 U2 R|]
 
 tOll :: Algorithm
 tOll = reverseMoveSeq lOll
 
 uOll :: Algorithm
-uOll = [R2, D, R', U2, R, D', R', U2, R']
+uOll = [algExpr|R2 D R' U2 R D' R' U2 R'|]

--- a/src/CFOP/PLL.hs
+++ b/src/CFOP/PLL.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE QuasiQuotes #-}
 module CFOP.PLL (pll, pllSolved) where
 
 import Control.Monad.State
@@ -7,6 +8,7 @@ import Triggers
 import CFOP.Cross (crossSolved)
 import CFOP.F2L (f2lSolved)
 import CFOP.OLL (ollSolved)
+import AlgExpr
 
 data PLLCategory = EdgesOnly | AdjecentCornerSwap | DiagonalCornerSwap
     deriving (Eq, Show)
@@ -75,13 +77,13 @@ edgesOnlyAlgs :: [Algorithm]
 edgesOnlyAlgs = applyFourSidesAlg [hPerm, zPerm, uaPerm, ubPerm]
 
 hPerm :: Algorithm
-hPerm = [R2, U2, R, U2, R2, U2, R2, U2, R, U2, R2]
+hPerm = [algExpr|R2 U2 R U2 R2 U2 R2 U2 R U2 R2|]
 
 zPerm :: Algorithm
-zPerm = [R', U', R, U', R, U, R, U', R', U, R, U, R2, U', R']
+zPerm = [algExpr|R' U' R U' R U R U' R' U R U R2 U' R'|]
 
 uaPerm :: Algorithm
-uaPerm = [R, U', R, U, R, U, R, U', R', U', R2]
+uaPerm = [algExpr|R U' R U R U R U' R' U' R2|]
 
 ubPerm :: Algorithm
 ubPerm = reverseMoveSeq uaPerm
@@ -106,31 +108,31 @@ adjecentCornerSwapAlgs = applyFourSidesAlg
 
 tPerm :: Algorithm
 tPerm =
-    sexy ++ [R', F, R2, U', R', U', R, U, R', F']
+    sexy ++ [algExpr|R' F R2 U' R' U' R U R' F'|]
 
 jaPerm :: Algorithm
-jaPerm = [R, U', L', U, R', U2, L, U', L', U2, L]
+jaPerm = [algExpr|R U' L' U R' U2 L U' L' U2 L|]
 
 jbPerm :: Algorithm
-jbPerm = [R, U, R', F'] ++ sexy ++ [R', F, R2, U', R']
+jbPerm = [algExpr|R U R' F'|] ++ sexy ++ [algExpr|R' F R2 U' R'|]
 
 fPerm :: Algorithm
-fPerm = [R', U', F'] ++ init tPerm ++ [U, R]
+fPerm = [algExpr|R' U' F'|] ++ init tPerm ++ [algExpr|U R|]
 
 aaPerm :: Algorithm
-aaPerm = [R', F, R', B2, R, F', R', B2, R2]
+aaPerm = [algExpr|R' F R' B2 R F' R' B2 R2|]
 
 abPerm :: Algorithm
 abPerm = reverseMoveSeq aaPerm
 
 raPerm :: Algorithm
-raPerm = [R, U, R', F', R, U2, R', U2, R', F, R, U, R, U2, R']
+raPerm = [algExpr|R U R' F' R U2 R' U2 R' F R U R U2 R'|]
 
 rbPerm :: Algorithm
-rbPerm = [R2, F, R, U, R, U', R', F', R, U2, R', U2, R]
+rbPerm = [algExpr|R2 F R U R U' R' F' R U2 R' U2 R|]
 
 gaPerm :: Algorithm
-gaPerm = [R2, U, R', U, R', U', R, U', R2, U', D, R', U, R, D']
+gaPerm = [algExpr|R2 U R' U R' U' R U' R2 U' D R' U R D'|]
 
 gbPerm :: Algorithm
 gbPerm = reverseMoveSeq gaPerm
@@ -147,16 +149,16 @@ diagonalCornerSwapAlgs :: [Algorithm]
 diagonalCornerSwapAlgs = applyFourSidesAlg [yPerm, vPerm, naPerm, nbPerm, ePerm]
 
 yPerm :: Algorithm
-yPerm = [F, R, U', R', U', R, U, R', F'] ++ sexy ++ sledgeHammer
+yPerm = [algExpr|F R U' R' U' R U R' F'|] ++ sexy ++ sledgeHammer
 
 vPerm :: Algorithm
-vPerm = [R, U', R, U, R', D, R, D', R, U', D, R2, U, R2, D', R2]
+vPerm = [algExpr|R U' R U R' D R D' R U' D R2 U R2 D' R2|]
 
 ePerm :: Algorithm
-ePerm = [R', U', R', D', R, U', R', D, R, U, R', D', R, U, R', D, R2]
+ePerm = [algExpr|R' U' R' D' R U' R' D R U R' D' R U R' D R2|]
 
 naPerm :: Algorithm
-naPerm = [R, U, R', U] ++ jbPerm ++ [U2, R, U', R']
+naPerm = [algExpr|R U R' U|] ++ jbPerm ++ [algExpr|U2 R U' R'|]
 
 nbPerm :: Algorithm
-nbPerm = [R', U, R, U', R', F', U', F, R, U, R', F, R', F', R, U', R]
+nbPerm = [algExpr|R' U R U' R' F' U' F R U R' F R' F' R U' R|]

--- a/src/Cube.hs
+++ b/src/Cube.hs
@@ -1,15 +1,16 @@
-{-# Language PatternSynonyms #-}
+{-# Language PatternSynonyms, DeriveDataTypeable #-}
 module Cube where
 
 import CubeState
 
 import Control.Monad.State
 import Data.List (minimumBy)
+import Data.Data
 
 type Cube a = State CubeState a
 
 data MoveDirection = Normal | Prime | Two
-    deriving (Eq, Show)
+    deriving (Eq, Show, Data, Typeable)
 
 data MoveFace = 
       FFace
@@ -18,7 +19,7 @@ data MoveFace =
     | BFace
     | LFace
     | DFace
-    deriving (Eq)
+    deriving (Eq, Data, Typeable)
 
 instance Show MoveFace where
     show FFace = "F"
@@ -29,7 +30,7 @@ instance Show MoveFace where
     show DFace = "D"
 
 data Move = Move MoveFace MoveDirection
-    deriving (Eq)
+    deriving (Eq, Data, Typeable)
 
 pattern F :: Move
 pattern F = Move FFace Normal

--- a/src/Cube.hs
+++ b/src/Cube.hs
@@ -1,4 +1,4 @@
-{-# Language PatternSynonyms, DeriveDataTypeable #-}
+{-# Language DeriveDataTypeable #-}
 module Cube where
 
 import CubeState
@@ -31,48 +31,6 @@ instance Show MoveFace where
 
 data Move = Move MoveFace MoveDirection
     deriving (Eq, Data, Typeable)
-
-pattern F :: Move
-pattern F = Move FFace Normal
-pattern F' :: Move
-pattern F' = Move FFace Prime
-pattern F2 :: Move
-pattern F2 = Move FFace Two
-
-pattern R :: Move
-pattern R = Move RFace Normal
-pattern R' :: Move
-pattern R' = Move RFace Prime
-pattern R2 :: Move
-pattern R2 = Move RFace Two
-
-pattern U :: Move
-pattern U = Move UFace Normal
-pattern U' :: Move
-pattern U' = Move UFace Prime
-pattern U2 :: Move
-pattern U2 = Move UFace Two
-
-pattern B :: Move
-pattern B = Move BFace Normal
-pattern B' :: Move
-pattern B' = Move BFace Prime
-pattern B2 :: Move
-pattern B2 = Move BFace Two
-
-pattern L :: Move
-pattern L = Move LFace Normal
-pattern L' :: Move
-pattern L' = Move LFace Prime
-pattern L2 :: Move
-pattern L2 = Move LFace Two
-
-pattern D :: Move
-pattern D = Move DFace Normal
-pattern D' :: Move
-pattern D' = Move DFace Prime
-pattern D2 :: Move
-pattern D2 = Move DFace Two
 
 type Algorithm = [Move]
 

--- a/src/MoveExpr.hs
+++ b/src/MoveExpr.hs
@@ -1,0 +1,5 @@
+module MoveExpr where
+
+import qualified Language.Haskell.TH as TH
+import Language.Haskell.TH.Quote
+

--- a/src/MoveExpr.hs
+++ b/src/MoveExpr.hs
@@ -1,5 +1,0 @@
-module MoveExpr where
-
-import qualified Language.Haskell.TH as TH
-import Language.Haskell.TH.Quote
-

--- a/src/Triggers.hs
+++ b/src/Triggers.hs
@@ -1,16 +1,18 @@
+{-# LANGUAGE QuasiQuotes #-}
 module Triggers where
 
 import Cube
+import AlgExpr
 
 -- This is a totally legit speedcubing term, I promise
 sexy :: Algorithm
-sexy = [R, U, R', U']
+sexy = [algExpr|R U R' U'|]
 
 reverseSexy :: Algorithm
 reverseSexy = reverseMoveSeq sexy
 
 sledgeHammer :: Algorithm
-sledgeHammer = [R', F, R, F']
+sledgeHammer = [algExpr|R' F R F'|]
 
 hedgeSlammer :: Algorithm
 hedgeSlammer = reverseMoveSeq sledgeHammer


### PR DESCRIPTION
Using quasi quotes from template haskell to replace pattern synonyms. Now it is possible to copy algorithms straight into the code without adding commas, as long as there are no slice moves.